### PR TITLE
Secure tag merge

### DIFF
--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -7,18 +7,18 @@ tags:
 {{/if}}
 manifests:
   -
-    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-linux-amd64
+    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-linux-arm64
+    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
   -
-    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-windows-amd64
+    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-amd64
     platform:
       architecture: amd64
       os: windows

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}secure{{/if}}
+image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,18 +7,18 @@ tags:
 {{/if}}
 manifests:
   -
-    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-linux-amd64
+    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-linux-arm64
+    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
   -
-    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-windows-amd64
+    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}latest-windows-amd64
     platform:
       architecture: amd64
       os: windows

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}secure{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,18 +7,18 @@ tags:
 {{/if}}
 manifests:
   -
-    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-linux-arm64
     platform:
       variant: v8
       architecture: arm64
       os: linux
   -
-    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-amd64
+    image: plugins/aws-oidc:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}secure-windows-amd64
     platform:
       architecture: amd64
       os: windows

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -62,7 +62,7 @@ func Exec(ctx context.Context, args Args) error {
 }
 
 func WriteEnvToFile(key, value string) error {
-	outputFile, err := os.OpenFile(os.Getenv("DRONE_OUTPUT"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	outputFile, err := os.OpenFile(os.Getenv("HARNESS_OUTPUT_SECRET_FILE"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open output file: %w", err)
 	}


### PR DESCRIPTION
changes : allowing aws-oidc to export output as secrets . checked in db and confirmed only one customer (data-robot) is using this plugin with secure tag so it wont effect them. 

`db.getCollection("pipelinesPMS").aggregate([
    {
        $match: {
            "yaml": {
                $regex: "image:\\s*plugins/aws-oidc:[\\w.-]+",
                $options: "i"  // case-insensitive search
            }
        }
    },
    {
        $group: {
            _id: "$accountId"  // assuming the account ID field is named 'accountId'
        }
    },
    {
        $project: {
            _id: 0,
            accountId: "$_id"
        }
    }
],{ "readPreference": { "mode": "secondary" }, "maxTimeMS": 100000 });`

